### PR TITLE
Fixed an issue with the Guid hashcode

### DIFF
--- a/lib/flutter_guid.dart
+++ b/lib/flutter_guid.dart
@@ -66,7 +66,7 @@ class Guid {
   /// Returns the hashCode.
   @override
   int get hashCode {
-    return super.hashCode;
+    return UuidValue.fromList(Uuid.parse(value)).hashCode;
   }
 
   /// Gets the UUID value contained by the Guid object as a string.

--- a/test/guid_test.dart
+++ b/test/guid_test.dart
@@ -21,6 +21,40 @@ void main() {
 
       expect(areEqual, false);
     });
+
+    test("Hashcodes for GUIDs with the same value should be the same", () {
+      final guidAlpha = new Guid("ac3fa00f-8f5b-4e93-b7a5-2ee3051a12b9");
+      final guidBeta = new Guid("ac3fa00f-8f5b-4e93-b7a5-2ee3051a12b9");
+
+      expect(guidAlpha.hashCode, guidBeta.hashCode);
+    });
+
+     test("GUID value casing should not affect hashcodes", () {
+      final guidAlpha = new Guid("ac3fa00f-8f5b-4e93-b7a5-2ee3051a12b9");
+      final guidBeta = new Guid("AC3FA00F-8F5B-4E93-B7A5-2EE3051A12B9");
+
+      expect(guidAlpha.hashCode, guidBeta.hashCode);
+    });
+
+    test("Hashcodes for GUIDs with different values should be different", () {
+      final guidAlpha = new Guid("ac3fa00f-8f5b-4e93-b7a5-2ee3051a12b9");
+      final guidBeta = new Guid("f841928c-5393-4c6e-9b22-85de1fcf317a");
+
+      expect(guidAlpha.hashCode != guidBeta.hashCode, true);
+    });
+
+    test("Separate GUIDs with the same underlying value should point to the same Map value", () {
+      final guidValue = "ac3fa00f-8f5b-4e93-b7a5-2ee3051a12b9";
+      final guidAlpha = Guid(guidValue);
+      final guidBeta = Guid(guidValue);
+
+      final Map<Guid, int> map = <Guid, int>{
+        guidAlpha: 2
+      };
+
+      expect(map.containsKey(guidAlpha), true);
+      expect(map.containsKey(guidBeta), true);
+    });
   });
 
   group("Validity Tests", () {


### PR DESCRIPTION
- The hashcode for a GUID should be the same across instances if the underlying value is the same. This behavior is inline with that of C# where separate GUIDs constructed with the same value generate the same hashcode
- The current hashcode implementation represents the identity of the object but is not tied to the value
- Updated the hashCode property to leverage existing Uuid mechanisms for hashcode generation
- This fix allows for the Guid type to be used as Map keys with the desired/expected behavior
- Updated unit tests